### PR TITLE
Fix compile error with msvc19

### DIFF
--- a/test/test_main.c
+++ b/test/test_main.c
@@ -1,5 +1,5 @@
-#include <CUnit/Basic.h>
 #include <stdio.h>
+#include <CUnit/Basic.h>
 #include "./shopping_cart_test.h"
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
CUnit defines `sprintf` which conflict with CRT of msvc (tested on Visual Studio 2019)

There's a macro check in stdio.h of msvc CRT:

```C++
    #if defined snprintf
        // This definition of snprintf will generate "warning C4005: 'snprintf': macro
        // redefinition" with a subsequent line indicating where the previous definition
        // of snprintf was.  This makes it easier to find where snprintf was defined.
        #pragma warning(push, 1)
        #pragma warning(1: 4005)
        #define snprintf Do not define snprintf as a macro
        #pragma warning(pop)
        #error Macro definition of snprintf conflicts with Standard Library function declaration
    #endif
```

Which check snprintf and throw error, but CUnit somehow direct snprintf to _snprintf to in CUnit.h:

```C++
#  ifdef _MSC_VER
#    define snprintf _snprintf
#  endif
```

This could be considered a bug of CUnit, but we can avoid it by simply include <stdio.h> prior to CUnit.h.